### PR TITLE
Combined dependency updates (2023-06-18)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           fail_on_failure: 'true'
       - name: Publish converted sources & test report files
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: converted sources & test reports
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v2
         with:
           distribution: 'temurin'

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
+			<version>2.13.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 		    <groupId>io.github.javiertuya</groupId>
 		    <artifactId>visual-assert</artifactId>
-		    <version>2.3.0</version>
+		    <version>2.4.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/checkout from 2 to 3](https://github.com/javiertuya/sharpen-action/pull/2)
- [Bump actions/upload-artifact from 2 to 3](https://github.com/javiertuya/sharpen-action/pull/3)
- [Bump commons-io from 2.11.0 to 2.13.0 in /test](https://github.com/javiertuya/sharpen-action/pull/4)
- [Bump visual-assert from 2.3.0 to 2.4.1 in /test](https://github.com/javiertuya/sharpen-action/pull/5)

Does not include these updates because of merge conflicts:
- [Bump actions/setup-java from 2 to 3](https://github.com/javiertuya/sharpen-action/pull/1)