### PR TITLE
Combined dependency updates (2023-10-03)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/test"
     schedule:
       interval: monthly
-    assignees:
-      - "javiertuya" 
     open-pull-requests-limit: 20
 
   - package-ecosystem: github-actions
@@ -13,5 +11,3 @@ updates:
     schedule:
       interval: monthly
     open-pull-requests-limit: 20
-    assignees:
-      - "javiertuya" 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         run: cd test && mvn test --no-transfer-progress -Dmaven.test.failure.ignore=true
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v3.8.0
+        uses: mikepenz/action-junit-report@v4.0.1
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           fail_on_failure: 'true'
       - name: Publish converted sources & test report files
         if: always()
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: converted sources & test reports
           path: |

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.13.0</version>
+			<version>2.14.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Includes these updates:
- [Update dependabot.yml assignee](https://github.com/javiertuya/sharpen-action/pull/13)
- [Bump actions/checkout from 3 to 4](https://github.com/javiertuya/sharpen-action/pull/11)
- [Bump actions/upload-artifact from 3.1.2 to 3.1.3](https://github.com/javiertuya/sharpen-action/pull/10)
- [Bump mikepenz/action-junit-report from 3.8.0 to 4.0.1](https://github.com/javiertuya/sharpen-action/pull/9)
- [Bump commons-io:commons-io from 2.13.0 to 2.14.0 in /test](https://github.com/javiertuya/sharpen-action/pull/12)