### PR TITLE
Combined dependency updates (2023-12-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.15.0</version>
+			<version>2.15.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-java from 3 to 4](https://github.com/javiertuya/sharpen-action/pull/18)
- [Bump commons-io:commons-io from 2.15.0 to 2.15.1 in /test](https://github.com/javiertuya/sharpen-action/pull/19)