### PR TITLE
Combined dependency updates (2024-05-01)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           fail_on_failure: 'true'
       - name: Publish converted sources & test report files
         if: always()
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.3.3
         with:
           name: converted sources & test reports
           path: |

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.16.0</version>
+			<version>2.16.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/upload-artifact from 4.3.1 to 4.3.3](https://github.com/javiertuya/sharpen-action/pull/32)
- [Bump commons-io:commons-io from 2.16.0 to 2.16.1 in /test](https://github.com/javiertuya/sharpen-action/pull/31)