### PR TITLE
Combined dependency updates (2024-09-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           fail_on_failure: 'true'
       - name: Publish converted sources & test report files
         if: always()
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: converted sources & test reports
           path: |

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 		    <groupId>io.github.javiertuya</groupId>
 		    <artifactId>visual-assert</artifactId>
-		    <version>2.4.2</version>
+		    <version>2.5.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump io.github.javiertuya:visual-assert from 2.4.2 to 2.5.0 in /test](https://github.com/javiertuya/sharpen-action/pull/41)
- [Bump actions/upload-artifact from 4.3.4 to 4.4.0](https://github.com/javiertuya/sharpen-action/pull/40)