### PR TITLE
Combined dependency updates (2024-12-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         run: cd test && mvn test --no-transfer-progress -Dmaven.test.failure.ignore=true
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v4.3.1
+        uses: mikepenz/action-junit-report@v5.1.0
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.17.0</version>
+			<version>2.18.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump commons-io:commons-io from 2.17.0 to 2.18.0 in /test](https://github.com/javiertuya/sharpen-action/pull/48)
- [Bump mikepenz/action-junit-report from 4.3.1 to 5.1.0](https://github.com/javiertuya/sharpen-action/pull/47)