### PR TITLE
Combined dependency updates (2025-02-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           fail_on_failure: 'true'
       - name: Publish converted sources & test report files
         if: always()
-        uses: actions/upload-artifact@v4.5.0
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: converted sources & test reports
           path: |


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/upload-artifact from 4.5.0 to 4.6.0](https://github.com/javiertuya/sharpen-action/pull/54)
- [Bump mikepenz/action-junit-report from 5.2.0 to 5.3.0](https://github.com/javiertuya/sharpen-action/pull/53)