### PR TITLE
Combined dependency updates (2025-04-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         run: cd test && mvn test --no-transfer-progress -Dmaven.test.failure.ignore=true
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v5.4.0
+        uses: mikepenz/action-junit-report@v5.5.1
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           fail_on_failure: 'true'
       - name: Publish converted sources & test report files
         if: always()
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: converted sources & test reports
           path: |

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -31,7 +31,7 @@
 		<dependency>
 		    <groupId>io.github.javiertuya</groupId>
 		    <artifactId>visual-assert</artifactId>
-		    <version>2.5.1</version>
+		    <version>2.6.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump io.github.javiertuya:visual-assert from 2.5.1 to 2.6.0 in /test](https://github.com/javiertuya/sharpen-action/pull/61)
- [Bump actions/upload-artifact from 4.6.1 to 4.6.2](https://github.com/javiertuya/sharpen-action/pull/60)
- [Bump mikepenz/action-junit-report from 5.4.0 to 5.5.1](https://github.com/javiertuya/sharpen-action/pull/59)