### PR TITLE
Combined dependency updates (2025-05-03)

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.18.0</version>
+			<version>2.19.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump commons-io:commons-io from 2.18.0 to 2.19.0 in /test](https://github.com/javiertuya/sharpen-action/pull/63)