### PR TITLE
Combined dependency updates (2025-08-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         run: cd test && mvn test --no-transfer-progress -Dmaven.test.failure.ignore=true
       - name: Publish test report
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.1
+        uses: mikepenz/action-junit-report@v5.6.2
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.19.0</version>
+			<version>2.20.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 5.6.1 to 5.6.2](https://github.com/javiertuya/sharpen-action/pull/70)
- [Bump commons-io:commons-io from 2.19.0 to 2.20.0 in /test](https://github.com/javiertuya/sharpen-action/pull/69)