### PR TITLE
Combined dependency updates (2026-05-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           fail_on_failure: 'true'
       - name: Publish converted sources & test report files
         if: always()
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: converted sources & test reports
           path: |

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.21.0</version>
+			<version>2.22.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/upload-artifact from 7.0.0 to 7.0.1](https://github.com/javiertuya/sharpen-action/pull/94)
- [Bump commons-io:commons-io from 2.21.0 to 2.22.0 in /test](https://github.com/javiertuya/sharpen-action/pull/93)